### PR TITLE
Add optional limit parameter to chirp read command

### DIFF
--- a/Chirp.CLI/Program.cs
+++ b/Chirp.CLI/Program.cs
@@ -1,14 +1,17 @@
 ﻿using System.Globalization;
+
 using CsvHelper;
+
 using DocoptNet;
+
 using SimpleDB;
 
 namespace Chirp.CLI;
 
-
-class Program
+internal class Program
 {
     public record Cheep(string Author, string Message, long Timestamp);
+
     public static string DATABASE_PATH = "./chirp_cli_db.csv";
 
     //Using @ to create verbatim string, which means that no escapes are needed
@@ -16,7 +19,7 @@ class Program
     private const string Usage = @"Chirp.
 
 Usage:
-  chirp read
+  chirp read [<limit>]
   chirp cheep <message>
   chirp (-h | --help)
 
@@ -27,24 +30,34 @@ Options:
     public static void Main(string[] args)
     {
         IDatabaseRepository<Cheep> db = new CSVDatabase<Cheep>(DATABASE_PATH);
-        var arguments = new Docopt().Apply(Usage, args, exit: true);
-        if (arguments == null) throw new NullReferenceException("CLI argument parsing failed\narguments is null");
+        IDictionary<string, ValueObject>? arguments = new Docopt().Apply(Usage, args, exit: true);
+        if (arguments == null)
+        {
+            throw new NullReferenceException("CLI argument parsing failed\narguments is null");
+        }
 
         if (arguments["read"].IsTrue)
         {
-            UserInterface.PrintCheeps(db.Read());
-        } else if (arguments["cheep"].IsTrue)
+            int? limit = null;
+            if (arguments["<limit>"].IsInt)
+            {
+                limit = arguments["<limit>"].AsInt;
+            }
+
+            UserInterface.PrintCheeps(db.Read(limit));
+        }
+        else if (arguments["cheep"].IsTrue)
         {
             AddCheep(arguments["<message>"].ToString(), db);
         }
     }
-    
+
     private static void AddCheep(string message, IDatabaseRepository<Cheep> db)
     {
-        var timestamp = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
-        var author = Environment.UserName;
-        
-        var cheep = new Cheep(author, message, timestamp);
+        long timestamp = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+        string author = Environment.UserName;
+
+        Cheep cheep = new(author, message, timestamp);
         db.Store(cheep);
     }
 }

--- a/SimpleDB/CSVDatabase.cs
+++ b/SimpleDB/CSVDatabase.cs
@@ -6,28 +6,32 @@ namespace SimpleDB;
 
 public sealed class CSVDatabase<T> : IDatabaseRepository<T>
 {
-    string DatabasePath;
-    private static readonly CultureInfo CultureInfo = new CultureInfo("en-DE");
+    private string DatabasePath;
+    private static readonly CultureInfo CultureInfo = new("en-DE");
+
     public CSVDatabase(string databasePath)
     {
-        this.DatabasePath = databasePath;
+        DatabasePath = databasePath;
     }
 
+    /// <summary>
+    /// Reads records from the CSV database, with an optional limit on the number of records returned.
+    /// </summary>
+    /// <param name="limit">Optional parameter to specify the maximum number of records to return.</param>
+    /// <returns>An enumerable collection of records of type T.</returns>
     public IEnumerable<T> Read(int? limit = null)
     {
-        using (var reader = new StreamReader(DatabasePath))
-        using (var csv = new CsvReader(reader, CultureInfo))
-        {
-            var records = csv.GetRecords<T>();
-            return records;
-        }
+        using StreamReader reader = new(DatabasePath);
+        using CsvReader csv = new(reader, CultureInfo);
+        IEnumerable<T> records = csv.GetRecords<T>();
+        return limit.HasValue ? records.TakeLast(limit.Value).ToList() : records.ToList();
     }
 
     public void Store(T record)
     {
-        using (var stream = File.Open(DatabasePath, FileMode.Append))
-        using (var writer = new StreamWriter(stream))
-        using (var csv = new CsvWriter(writer, CultureInfo))
+        using (FileStream stream = File.Open(DatabasePath, FileMode.Append))
+        using (StreamWriter writer = new(stream))
+        using (CsvWriter csv = new(writer, CultureInfo))
         {
             csv.WriteRecord(record);
             csv.NextRecord();


### PR DESCRIPTION
Implemented an optional limit parameter for the `chirp read` command to specify the number of cheeps returned. Modified CSVDatabase to handle limiting the number of records when reading from the database.