### PR TITLE
Added .zip to release file names

### DIFF
--- a/.github/workflows/publish_on_tags.yml
+++ b/.github/workflows/publish_on_tags.yml
@@ -59,10 +59,10 @@ jobs:
     - name: Zip files
       working-directory: "./src/Chirp.CLI/bin/Release/net8.0/"
       run: |
-        zip Chirp-${{ github.ref_name }}-win-x64 --junk-paths win-x64/publish/Chirp.CLI.exe
-        zip Chirp-${{ github.ref_name }}-linux-x64 --junk-paths linux-x64/publish/Chirp.CLI
-        zip Chirp-${{ github.ref_name }}-osx-x64 --junk-paths osx-x64/publish/Chirp.CLI
-        zip Chirp-${{ github.ref_name }}-osx-arm64 --junk-paths osx-arm64/publish/Chirp.CLI
+        zip Chirp-${{ github.ref_name }}-win-x64.zip --junk-paths win-x64/publish/Chirp.CLI.exe
+        zip Chirp-${{ github.ref_name }}-linux-x64.zip --junk-paths linux-x64/publish/Chirp.CLI
+        zip Chirp-${{ github.ref_name }}-osx-x64.zip --junk-paths osx-x64/publish/Chirp.CLI
+        zip Chirp-${{ github.ref_name }}-osx-arm64.zip --junk-paths osx-arm64/publish/Chirp.CLI
     - name:
       uses: softprops/action-gh-release@v2
       with: 


### PR DESCRIPTION
This was done to make the release file executables be added to the automated release on version tag push