### PR TITLE
Set Chirp.Web target framework to .NET 8.0

### DIFF
--- a/src/Chirp.Web/Chirp.Web.csproj
+++ b/src/Chirp.Web/Chirp.Web.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net$(NETCoreAppMaximumVersion)</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
     </PropertyGroup>


### PR DESCRIPTION
This fixes a bug where the wrong SDK is used if the user has .NET 9 preview installed on their machine.