### PR TITLE
Replaced placeholder and text in login field

### DIFF
--- a/src/Chirp.Web/Areas/Identity/Pages/Account/Login.cshtml
+++ b/src/Chirp.Web/Areas/Identity/Pages/Account/Login.cshtml
@@ -14,8 +14,8 @@
                 <hr />
                 <div asp-validation-summary="ModelOnly" class="text-danger" role="alert"></div>
                 <div class="form-floating mb-3">
-                    <input asp-for="Input.Username" class="form-control" autocomplete="username" aria-required="true" placeholder="JohnDoe" />
-                    <label asp-for="Input.Username" class="form-label">User Name</label>
+                    <input asp-for="Input.Username" class="form-control" autocomplete="username" aria-required="true" placeholder="name@example.com" />
+                    <label asp-for="Input.Username" class="form-label">Email</label>
                     <span asp-validation-for="Input.Username" class="text-danger"></span>
                 </div>
                 <div class="form-floating mb-3">


### PR DESCRIPTION
This was done to make the user aware that we are asking for their email and not their username