### PR TITLE
Refactor user null check to avoid exception during GitHub registration

### DIFF
--- a/src/Chirp.Web/AuthorClaimsTransformation.cs
+++ b/src/Chirp.Web/AuthorClaimsTransformation.cs
@@ -18,16 +18,18 @@ public class AuthorClaimsTransformation : IClaimsTransformation
     public async Task<ClaimsPrincipal> TransformAsync(ClaimsPrincipal principal)
     {
         var claimsIdentity = new ClaimsIdentity();
-        var claimType = "Beak";
+        const string claimType = "Beak";
         if (!principal.HasClaim(claim => claim.Type == claimType))
         {
             var user = await _userManager.GetUserAsync(principal);
-            if (user == null)
+            
+            // If the user is in the middle of registering using an external login, the user is not yet created
+            if (user != null)
             {
-                throw new NullReferenceException("No user type found");
+                claimsIdentity.AddClaim(new Claim(claimType, user.Beak));
             }
-            claimsIdentity.AddClaim(new Claim(claimType, user.Beak));
         }
+
         principal.AddIdentity(claimsIdentity);
         return principal;
     }


### PR DESCRIPTION
Previously, a NullReferenceException was thrown if a user was not yet created during the claims transformation. The updated code now handles this case by simply not adding the Beak claim if the user is null, improving stability.