### PR TITLE
Made compile_report using self made docker image

### DIFF
--- a/.github/workflows/compile_report.yml
+++ b/.github/workflows/compile_report.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: docker://pandoc/latex:3.5
+      - uses: docker://olivers8/pandoc-latex-plantuml
         with:
           args: --output=docs/report.pdf docs/report.md  
           


### PR DESCRIPTION
This was done to allow for adding the a python package that enables to convert plantuml to images, when compiling with pandoc